### PR TITLE
Fix HP calculation bug in character sheet

### DIFF
--- a/Charactercreation.html
+++ b/Charactercreation.html
@@ -322,7 +322,7 @@
                 e('div', { className: "text-2xl font-bold" }, `${value >= 0 ? '+' : ''}${value}`)
             );
             
-            const hp = 4 * (9 + character.attributes.SOM);
+            const hp = 4 + character.attributes.SOM;
             const load = 9 + character.attributes.SOM;
 
             return e(StepContainer, { title: "Character Profile" },


### PR DESCRIPTION
## Summary
- Correct HP formula in character sheet to use base value plus SOM attribute

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68987df25178832592aadd8197fae286